### PR TITLE
Use numpy.ptp(arr) for resample button

### DIFF
--- a/src/napari_manual_transforms/_util.py
+++ b/src/napari_manual_transforms/_util.py
@@ -43,7 +43,7 @@ def transform_array_3d(
             [0, ix, 0, ix, 0, ix, 0, ix],
         ]
         # Compute the shape of the transformed input
-        out_shape = (out_bounds.ptp(axis=1) + 0.5).astype(int)
+        out_shape = (np.ptp(out_bounds, axis=1) + 0.5).astype(int)
 
         # make new larger input array.
         # FIXME: there has to be a more efficient way using output_shape and


### PR DESCRIPTION
When testing the **resample**-button during #2, I noticed that NumPy 2.0 has removed the `arr.ptp(...)` function.

This PR uses `numpy.ptp(array, ...)` instead to resolve the error.

Should be backward-compatible as earlier NumPy version also support this function:

https://numpy.org/doc/1.13/reference/generated/numpy.ptp.html
https://numpy.org/doc/1.26/reference/generated/numpy.ptp.html